### PR TITLE
Email, avatar and publishing configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@
 CFX_APP_NAME=Laravel
 CFX_CLIENT_ID=UNIQUE_CLIENT_ID
 CFX_REDIRECT_URL=http://127.0.0.1:8000/callback
+CFX_AVATAR_SIZE=128
 ```
 The `CFX_APP_NAME` is the application name listed at the [apps page](https://forum.cfx.re/u/sarahwinter/preferences/apps). \
 Make sure to generate a **random* and **unique** `CFX_CLIENT_ID` you can generate this key yourself. \
+The `CFX_AVATAR_SIZE` determines the size at which the avatar is returned. Please note that values lower than 8 and higher than 1000 will result in a blank avatar. This is because Discourse has hardcoded these limits in their avatar controller. \
 Unless a real OAuth flow Discourse forums do not require any way of application registration.
 
 ## Scopes

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ CFX_CLIENT_ID=UNIQUE_CLIENT_ID
 CFX_REDIRECT_URL=http://127.0.0.1:8000/callback
 CFX_AVATAR_SIZE=128
 ```
+Alternatively, you can also publish the configuration file using `php artisan vendor:publish --tag=cfx-config`.
+
 The `CFX_APP_NAME` is the application name listed at the [apps page](https://forum.cfx.re/u/sarahwinter/preferences/apps). \
 Make sure to generate a **random* and **unique** `CFX_CLIENT_ID` you can generate this key yourself. \
 The `CFX_AVATAR_SIZE` determines the size at which the avatar is returned. Please note that values lower than 8 and higher than 1000 will result in a blank avatar. This is because Discourse has hardcoded these limits in their avatar controller. \

--- a/config/cfx.php
+++ b/config/cfx.php
@@ -5,4 +5,5 @@ return [
     'client_id' => env('CFX_CLIENT_ID', base64_encode(env('APP_NAME'))),
     'client_secret' => null, /* Unused, required by Socialite */
     'redirect' => env('CFX_REDIRECT_URL'),
+    'avatar_size' => env('CFX_AVATAR_SIZE', 128),
 ];

--- a/src/CfxProvider.php
+++ b/src/CfxProvider.php
@@ -73,7 +73,7 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getCodeFields($state = null): array
     {
-        $scopes = array_merge(["session_info"], $this->getScopes());
+        $scopes = array_merge(["read"], $this->getScopes());
 
         return [
             "auth_redirect" => $this->redirectUrl,

--- a/src/CfxProvider.php
+++ b/src/CfxProvider.php
@@ -236,7 +236,7 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
     {
         $baseUrl = self::$BASE_URL;
 
-        return $baseUrl . str_replace('{size}', '128', $user['avatar_template']);
+        return $baseUrl . str_replace('{size}', config('cfx.avatar_size'), $user['avatar_template']);
     }
 
     /**

--- a/src/CfxProvider.php
+++ b/src/CfxProvider.php
@@ -204,7 +204,7 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
             RequestOptions::HEADERS => $this->getTokenHeaders($token),
         ]);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody(), true)['current_user'];
     }
 
     /**
@@ -247,8 +247,6 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user): User
     {
-        $user = $user['current_user'];
-
         return (new User())->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => $user['username'],

--- a/src/CfxProvider.php
+++ b/src/CfxProvider.php
@@ -227,6 +227,19 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
+     * Format the avatar_template field to create a correct link
+     *
+     * @param array $user
+     * @return string
+     */
+    protected function formatAvatar(array $user): string
+    {
+        $baseUrl = self::$BASE_URL;
+
+        return $baseUrl . str_replace('{size}', '128', $user['avatar_template']);
+    }
+
+    /**
      * Map the returned data to a socialite user object.
      *
      * @param array $user
@@ -240,7 +253,7 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
             'id' => $user['id'],
             'nickname' => $user['username'],
             'email' => $user['email'],
-            'avatar' => 'https://avatars.discourse-cdn.com/v4/letter/s/49beb7/128.png',
+            'avatar' => $this->formatAvatar($user),
         ]);
     }
 }

--- a/src/CfxProvider.php
+++ b/src/CfxProvider.php
@@ -169,8 +169,6 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
 
         return [
             'access_token' => $code,
-            'refresh_token' =>  '',
-            'expires_in' => '',
         ];
     }
 

--- a/src/CfxProvider.php
+++ b/src/CfxProvider.php
@@ -193,10 +193,10 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
      * Gets the user information from the session endpoint.
      *
      * @param $token
-     * @return array|mixed
+     * @return array
      * @throws GuzzleException
      */
-    protected function getUserByToken($token)
+    protected function getCurrentUser($token): array
     {
         $baseUrl = self::$BASE_URL;
 
@@ -205,6 +205,25 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
         ]);
 
         return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * Gets the user information from the users endpoint.
+     *
+     * @param $token
+     * @return array|mixed
+     * @throws GuzzleException
+     */
+    protected function getUserByToken($token): mixed
+    {
+        $baseUrl = self::$BASE_URL;
+        $username = $this->getCurrentUser($token)['username'];
+
+        $response = $this->getHttpClient()->get("$baseUrl/users/$username.json", [
+            RequestOptions::HEADERS => $this->getTokenHeaders($token)
+        ]);
+
+        return json_decode($response->getBody(), true)['user'];
     }
 
     /**
@@ -220,6 +239,7 @@ class CfxProvider extends AbstractProvider implements ProviderInterface
         return (new User())->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => $user['username'],
+            'email' => $user['email'],
             'avatar' => 'https://avatars.discourse-cdn.com/v4/letter/s/49beb7/128.png',
         ]);
     }

--- a/src/CfxServiceProvider.php
+++ b/src/CfxServiceProvider.php
@@ -33,6 +33,10 @@ class CfxServiceProvider extends ServiceProvider
             ]);
         }
 
+        $this->publishes([
+            __DIR__.'/../config/cfx.php' => config_path('cfx.php')
+        ], 'cfx-config');
+
         $socialite = $this->app->make(Factory::class);
 
         $socialite->extend('cfx', function ($app) use ($socialite) {


### PR DESCRIPTION
Hi there!

I've added support for the email address by utilising the `/users/:username.json` endpoint.
Next to that I also made the avatar field take the `avatar_template` field and turn it into a proper link with a config option for the image size.
I also published the configuration file.
And updated the README.md as well to include my changes.
